### PR TITLE
Listing should include Icons

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add contenttype class in menu, so the sprites are used there as well.
+  [Julian Infanger]
 
 
 1.0 (2013-05-24)

--- a/ftw/contenttemplates/browser/create_from_template.pt
+++ b/ftw/contenttemplates/browser/create_from_template.pt
@@ -33,7 +33,8 @@
                        tal:attributes="value template/getPath;
                                        id string:template_${template/UID}"
                        />
-                <label tal:attributes="for string:template_${template/UID}"
+                <label tal:attributes="for string:template_${template/UID};
+                                       class python:view.css_class(template)"
                        tal:content="template/Title">
                 </label>
               </dt>

--- a/ftw/contenttemplates/browser/create_from_template.py
+++ b/ftw/contenttemplates/browser/create_from_template.py
@@ -7,6 +7,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from ftw.contenttemplates import _
 from ftw.contenttemplates.interfaces import IContentTemplatesSettings
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.memoize import view
 from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
@@ -18,6 +19,9 @@ class CreateFromTemplate(BrowserView):
 
     def __call__(self):
         messages = IStatusMessage(self.request)
+        # define normalizer
+        idnormalizer = queryUtility(IIDNormalizer)
+        self.normalize = idnormalizer.normalize
         # handle cancel
         if self.request.form.get('form.cancel', None):
             messages.addStatusMessage(
@@ -55,6 +59,11 @@ class CreateFromTemplate(BrowserView):
         return [path.lstrip('/').encode('utf8')
                 for path in settings.template_folder
                 if path]
+
+    def css_class(self, template):
+        """ Returns the objects css class containing the normalized portal type for sprite.
+        """
+        return "contenttype-%s" % self.normalize(template.portal_type)
 
     @view.memoize_contextless
     def templates(self):


### PR DESCRIPTION
The listing of the templates to choose from should be tabular and 
![bildschirmfoto 2013-05-29 um 16 00 10](https://f.cloud.github.com/assets/1231822/579021/6560133a-c868-11e2-89a0-cc60f91ece12.png)
include icons or even the Type, to look nicer and more readable.
